### PR TITLE
fix error when execute `init` command without a config file

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 
 	"github.com/skanehira/remonade/config"
 	"github.com/skanehira/remonade/util"
@@ -26,28 +25,17 @@ func runInit(path string) error {
 		err error
 	)
 
-	if notExist(path) {
-		base := filepath.Dir(path)
-		if notExist(base) {
-			if err := os.Mkdir(base, os.ModePerm); err != nil {
-				return err
-			}
-		}
-
-		f, err = os.Create(path)
-		if err != nil {
+	if util.NotExist(path) {
+		if err = config.Create(path); err != nil {
 			return err
 		}
-		defer f.Close()
-
-		fmt.Println("config file: " + path)
-	} else {
-		f, err = os.OpenFile(path, os.O_WRONLY, 0)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
 	}
+
+	f, err = os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
 
 	fmt.Print("Your access token: ")
 	sc := bufio.NewScanner(os.Stdin)
@@ -63,7 +51,7 @@ func runInit(path string) error {
 }
 
 func runEdit(path string) error {
-	if notExist(path) {
+	if util.NotExist(path) {
 		return ErrNotExistConfig
 	}
 
@@ -77,11 +65,6 @@ func runEdit(path string) error {
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
-}
-
-func notExist(path string) bool {
-	_, err := os.Stat(path)
-	return errors.Is(err, os.ErrNotExist)
 }
 
 func run(cmd *cobra.Command, args []string) {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -4,12 +4,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/skanehira/remonade/util"
 )
 
 func TestRunInit(t *testing.T) {
 	t.Run("empty token", func(t *testing.T) {
 		tmp := filepath.Join(os.TempDir(), "d")
-		if !notExist(tmp) {
+		if !util.NotExist(tmp) {
 			if err := os.RemoveAll(tmp); err != nil {
 				t.Fatal(err)
 			}
@@ -34,7 +36,7 @@ func TestRunInit(t *testing.T) {
 func TestRunEdit(t *testing.T) {
 	t.Run("no exists config", func(t *testing.T) {
 		tmp := filepath.Join(os.TempDir(), "d")
-		if !notExist(tmp) {
+		if !util.NotExist(tmp) {
 			if err := os.RemoveAll(tmp); err != nil {
 				t.Fatal(err)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,13 @@ func Init() {
 	}
 	Path = filepath.Join(path, "remonade", "config.yaml")
 
+	if util.NotExist(Path) {
+		if err := Create(Path); err != nil {
+			util.ExitError(err)
+		}
+		return
+	}
+
 	f, err := os.Open(Path)
 	if err != nil {
 		util.ExitError(err)
@@ -33,4 +40,22 @@ func Init() {
 	if err := yaml.NewDecoder(f).Decode(&Config); err != nil {
 		util.ExitError(err)
 	}
+}
+
+func Create(path string) error {
+	base := filepath.Dir(path)
+
+	if util.NotExist(base) {
+		if err := os.Mkdir(base, os.ModePerm); err != nil {
+			return err
+		}
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,9 +1,15 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
+
+func NotExist(path string) bool {
+	_, err := os.Stat(path)
+	return errors.Is(err, os.ErrNotExist)
+}
 
 func ExitError(msg interface{}) {
 	fmt.Fprintln(os.Stderr, msg)


### PR DESCRIPTION
If the `init` command is executed without a config file, `config.Init()` in the main function will generate a config file missing error.


https://user-images.githubusercontent.com/16238709/124295151-784e3980-db93-11eb-8844-ec4fe4161933.mov



I fixed it `config.Init()` to create the config file if it does not exist.